### PR TITLE
Fix dotnetRunMessages value in launchSettings.json

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "BlazingPizza": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {


### PR DESCRIPTION
This change fixes the dotnetRunMessages value in the launchSettings.json file for the BlazingPizza project.
Previously, the property was defined as a string ("true"), which caused issues when running the project in VS Code.
It has been corrected to a boolean (true) to align with expected configuration syntax and ensure proper runtime behavior.